### PR TITLE
Fix for deprecated function use and handling of WP_Error

### DIFF
--- a/envato-wordpress-toolkit-library/class-envato-protected-api.php
+++ b/envato-wordpress-toolkit-library/class-envato-protected-api.php
@@ -341,6 +341,11 @@ class Envato_Protected_API {
 
     $request = wp_remote_request( $url );
 
+    if ( is_wp_error( $request ) ) {
+    	echo $request->get_error_message();
+    	return false;
+    }
+
     $data = json_decode( $request['body'] );
     
     if ( $request['response']['code'] == 200 ) {

--- a/envato-wordpress-toolkit-library/class-envato-wordpress-theme-upgrader.php
+++ b/envato-wordpress-toolkit-library/class-envato-wordpress-theme-upgrader.php
@@ -69,7 +69,11 @@ if ( class_exists( 'Theme_Upgrader' ) && ! class_exists( 'Envato_WordPress_Theme
             }
             
             $purchased_themes             = $this->filter_purchased_themes_by_name($purchased_themes, $theme_name);
-            $result->updated_themes       = $this->get_updated_themes(get_themes(), $purchased_themes);
+            if ( function_exists( 'wp_get_themes' ) )
+            	$themes_list = wp_get_themes();
+            else
+            	$themes_list = get_themes();
+            $result->updated_themes       = $this->get_updated_themes($themes_list, $purchased_themes);
             $result->updated_themes_count = count($result->updated_themes);
             
             return $result; 
@@ -223,7 +227,10 @@ if ( class_exists( 'Theme_Upgrader' ) && ! class_exists( 'Envato_WordPress_Theme
 
         protected function is_theme_installed($theme_name) 
         {
-            $installed_themes = get_themes();
+        	if ( function_exists( 'wp_get_themes' ) )
+        		$installed_themes = wp_get_themes();
+        	else
+	            $installed_themes = get_themes();
             foreach($installed_themes as $entry) 
             {
                 if (strcmp($entry['Name'], $theme_name) == 0) {


### PR DESCRIPTION
An issue with WP_Error handling for the requests was raised here: http://themeforest.net/forums/thread/wp_error-as-array-in/94738

Also, get_themes() was deprecated in WordPress 3.4.
