### PR TITLE
Fixed cannot redeclare class error

### DIFF
--- a/envato-wordpress-toolkit-library/class-envato-wordpress-theme-upgrader.php
+++ b/envato-wordpress-toolkit-library/class-envato-wordpress-theme-upgrader.php
@@ -9,7 +9,9 @@
  */
 
 include_once( ABSPATH . 'wp-admin/includes/class-wp-upgrader.php' );
-include_once( 'class-envato-protected-api.php' );
+if ( !class_exists( 'Envato_Protected_API' ) ) {
+    include_once( 'class-envato-protected-api.php' );
+}
 
 if ( class_exists( 'Theme_Upgrader' ) && ! class_exists( 'Envato_WordPress_Theme_Upgrader' ) ) {
 


### PR DESCRIPTION
Error shows up if the toolkit plugin is already running / activated
